### PR TITLE
replace backticks to allow nested expressions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ module.exports = function () {
             render(fixedRaw)
               .replace(/"\{/g, '{').replace(/\}"/g, '}')
               .replace(/class="/g, 'className="').replace(/for="/g, 'htmlFor="')
+              .replace(/\\\`/g, '`')
           const {ast} = transform(html, {
             presets: ['react']
           })


### PR DESCRIPTION
This patch allows expressions like the following to work:

    pug`
      div {this.state.names.map((name) => pug\`span {name}\`)}

It seems too good to be true with so few lines but it does work, I'm guessing babel parses and transforms any new template strings which are created in the ast.
