### PR TITLE
trim fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ module.exports = function () {
       TaggedTemplateExpression (path, state) {
         if (path.node.tag.name === 'pug') {
           const {raw} = path.node.quasi.quasis[0].value
-          const splitedRaw = raw.split('\n').filter((str) => {return str !== ''})
+          const splitedRaw = raw.trimRight().split('\n').filter((str) => {return str !== ''})
           const rootIndent = /^\s*/.exec(splitedRaw[0])[0]
           const fixedRaw = splitedRaw.map((raw) => {
             const spaceRegExp = new RegExp(`^${rootIndent}`)

--- a/test/fixture/indent
+++ b/test/fixture/indent
@@ -1,7 +1,8 @@
-pug`
+    pug`
         .indent(data='{yoyo}')
           Foo(fuga='{this.props.fuga}')
           Bar(bar='{this.props.bar}')
             input(id='id', required)
             label(for='id')
-`
+          | text
+    `

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,8 @@ test('Transform pug literal(indent)', t => {
     { bar: this.props.bar },
     React.createElement("input", { id: "id", required: "required" }),
     React.createElement("label", { htmlFor: "id" })
-  )
+  ),
+  "text"
 );`)
 })
 


### PR DESCRIPTION
This trims the end of the string, which if not trimmed can show the following error:

    unexpected token "indent"
        at makeError (...\node_modules\pug-error\index.js:32:13)
        at Parser.error (...\node_modules\pug-parser\index.js:53:15)
        at Parser.parseExpr (...\node_modules\pug-parser\index.js:257:14)
        at Parser.block (...\node_modules\pug-parser\index.js:930:25)
        at Parser.tag (...\node_modules\pug-parser\index.js:1075:24)
        at Parser.parseTag (...\node_modules\pug-parser\index.js:977:17)
        at Parser.parseExpr (...\node_modules\pug-parser\index.js:202:21)
        at Parser.parseExpr (...\node_modules\pug-parser\index.js:253:21)
        at Parser.parse (...\node_modules\pug-parser\index.js:112:25)
        at parse (...\node_modules\pug-parser\index.js:12:20)

I think the reason is that when there are too many indents in the `render()` function:

    render () {
      if(true){
        if(true){
          if(true){
            if(true){
              if(true){
                if(true){
                  return pug`
                    .awesome#app
                      Foo
                  `
                }
              }
            }
          }
        }
      }
      return null
    }

The resulting string will be:

    `.awesome#app
        Foo
                      `

where the last part causes an indent error.
